### PR TITLE
Implement webhook and basic tests

### DIFF
--- a/InstagramAutomation.Api/Controllers/AuthController.cs
+++ b/InstagramAutomation.Api/Controllers/AuthController.cs
@@ -50,7 +50,7 @@ public class AuthController : ControllerBase
             {
                 Email = request.Email.ToLowerInvariant(),
                 PasswordHash = _passwordService.HashPassword(request.Password),
-                FullName = request.full_name,
+                FullName = request.FullName,
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow

--- a/InstagramAutomation.Api/Controllers/WebhookController.cs
+++ b/InstagramAutomation.Api/Controllers/WebhookController.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using InstagramAutomation.Api.Data;
+using InstagramAutomation.Api.DTOs;
+using InstagramAutomation.Api.Models;
+using InstagramAutomation.Api.Services;
+
+namespace InstagramAutomation.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WebhookController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+    private readonly ApplicationDbContext _context;
+    private readonly IInstagramApiService _instagram;
+    private readonly ILogger<WebhookController> _logger;
+
+    public WebhookController(IConfiguration configuration,
+        ApplicationDbContext context,
+        IInstagramApiService instagram,
+        ILogger<WebhookController> logger)
+    {
+        _configuration = configuration;
+        _context = context;
+        _instagram = instagram;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public IActionResult Verify([FromQuery(Name = "hub.mode")] string mode,
+        [FromQuery(Name = "hub.challenge")] string challenge,
+        [FromQuery(Name = "hub.verify_token")] string token)
+    {
+        var verifyToken = _configuration["Instagram:WebhookVerifyToken"];
+        if (mode == "subscribe" && token == verifyToken)
+        {
+            return Ok(challenge);
+        }
+        return Unauthorized();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Receive([FromBody] WebhookRequest request)
+    {
+        if (request.Entry == null)
+            return Ok();
+
+        foreach (var entry in request.Entry)
+        {
+            var account = await _context.InstagramAccounts
+                .FirstOrDefaultAsync(a => a.InstagramUserId == entry.Id);
+            if (account == null)
+                continue;
+
+            foreach (var change in entry.Changes)
+            {
+                if (change.Field != "comments")
+                    continue;
+
+                var comment = change.Value;
+                var commentEvent = new CommentEvent
+                {
+                    InstagramAccountId = account.Id,
+                    CommentId = comment.Id,
+                    MediaId = comment.Media.Id,
+                    CommenterId = comment.From.Id,
+                    CommenterUsername = comment.From.Username,
+                    CommentText = comment.Text,
+                    CommentTimestamp = DateTimeOffset.FromUnixTimeSeconds(entry.Time).UtcDateTime,
+                    MediaType = comment.Media.MediaType,
+                    WebhookData = JsonSerializer.Serialize(change)
+                };
+
+                _context.CommentEvents.Add(commentEvent);
+                await _context.SaveChangesAsync();
+
+                await ProcessRules(account, commentEvent);
+            }
+        }
+
+        return Ok();
+    }
+
+    private async Task ProcessRules(InstagramAccount account, CommentEvent commentEvent)
+    {
+        if (string.IsNullOrEmpty(account.AccessToken))
+            return;
+
+        var rules = await _context.AutomationRules
+            .Where(r => r.InstagramAccountId == account.Id && r.IsActive)
+            .OrderBy(r => r.Priority)
+            .ToListAsync();
+
+        foreach (var rule in rules)
+        {
+            if (!IsMatch(commentEvent.CommentText, rule))
+                continue;
+
+            if (!string.IsNullOrEmpty(rule.PublicResponse))
+            {
+                var exec = new ActionExecution
+                {
+                    CommentEventId = commentEvent.Id,
+                    AutomationRuleId = rule.Id,
+                    ActionType = "public_reply",
+                    Status = "pending",
+                    ResponseText = rule.PublicResponse,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                var success = await _instagram.PostCommentReplyAsync(account.AccessToken!, commentEvent.CommentId, rule.PublicResponse!);
+                exec.Status = success ? "success" : "failed";
+                exec.ExecutedAt = DateTime.UtcNow;
+                _context.ActionExecutions.Add(exec);
+            }
+
+            if (rule.SendPrivateMessage && !string.IsNullOrEmpty(rule.PrivateMessage))
+            {
+                var exec = new ActionExecution
+                {
+                    CommentEventId = commentEvent.Id,
+                    AutomationRuleId = rule.Id,
+                    ActionType = "private_message",
+                    Status = "pending",
+                    ResponseText = rule.PrivateMessage,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                var success = await _instagram.SendPrivateMessageAsync(account.AccessToken!, commentEvent.CommenterId, rule.PrivateMessage!);
+                exec.Status = success ? "success" : "failed";
+                exec.ExecutedAt = DateTime.UtcNow;
+                _context.ActionExecutions.Add(exec);
+            }
+
+            rule.ExecutionCount++;
+            rule.LastExecuted = DateTime.UtcNow;
+            commentEvent.Processed = true;
+            commentEvent.ProcessedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync();
+    }
+
+    private static bool IsMatch(string text, AutomationRule rule)
+    {
+        var comparison = rule.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        var keywords = rule.TriggerKeywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var kw in keywords)
+        {
+            if (rule.MatchType == "exact")
+            {
+                if (string.Equals(text, kw, comparison))
+                    return true;
+            }
+            else if (rule.MatchType == "partial")
+            {
+                if (text.Contains(kw, comparison))
+                    return true;
+            }
+            else if (rule.MatchType == "regex")
+            {
+                var options = rule.CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
+                if (Regex.IsMatch(text, kw, options))
+                    return true;
+            }
+            else if (rule.MatchType == "fuzzy")
+            {
+                if (text.Contains(kw, comparison))
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/InstagramAutomation.Api/DTOs/AuthDTOs.cs
+++ b/InstagramAutomation.Api/DTOs/AuthDTOs.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace InstagramAutomation.Api.DTOs;
 
@@ -14,7 +15,8 @@ public class RegisterRequest
 
     [Required(ErrorMessage = "Nome completo é obrigatório")]
     [StringLength(255, ErrorMessage = "Nome completo deve ter no máximo 255 caracteres")]
-    public string full_name { get; set; } = string.Empty;
+    [JsonPropertyName("full_name")]
+    public string FullName { get; set; } = string.Empty;
 }
 
 public class LoginRequest

--- a/InstagramAutomation.Api/Program.cs
+++ b/InstagramAutomation.Api/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // Services
 builder.Services.AddScoped<IJwtService, JwtService>();
 builder.Services.AddScoped<IPasswordService, PasswordService>();
+builder.Services.AddHttpClient<IInstagramApiService, InstagramApiService>();
 
 // JWT Authentication
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");

--- a/InstagramAutomation.Tests/InstagramAutomation.Tests.csproj
+++ b/InstagramAutomation.Tests/InstagramAutomation.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InstagramAutomation.Api\InstagramAutomation.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/InstagramAutomation.Tests/JwtServiceTests.cs
+++ b/InstagramAutomation.Tests/JwtServiceTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using InstagramAutomation.Api.Models;
+using InstagramAutomation.Api.Services;
+using Xunit;
+
+public class JwtServiceTests
+{
+    private readonly JwtService _service;
+
+    public JwtServiceTests()
+    {
+        var inMemorySettings = new Dictionary<string,string>
+        {
+            {"JwtSettings:SecretKey", "supersecretkeysupersecretkey123"},
+            {"JwtSettings:Issuer", "TestIssuer"},
+            {"JwtSettings:Audience", "TestAudience"},
+            {"JwtSettings:ExpirationMinutes", "60"}
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+        _service = new JwtService(configuration);
+    }
+
+    [Fact]
+    public void GenerateAndValidateToken_ReturnsClaims()
+    {
+        var user = new User { Id = 1, Email = "test@example.com", FullName = "Test" };
+        var token = _service.GenerateAccessToken(user);
+        var principal = _service.ValidateToken(token);
+        Assert.NotNull(principal);
+        Assert.Equal("1", principal!.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value);
+    }
+
+    [Fact]
+    public void GetUserIdFromToken_ReturnsUserId()
+    {
+        var user = new User { Id = 2, Email = "test2@example.com", FullName = "Test2" };
+        var token = _service.GenerateAccessToken(user);
+        var userId = _service.GetUserIdFromToken(token);
+        Assert.Equal(2, userId);
+    }
+}

--- a/InstagramAutomation.Tests/PasswordServiceTests.cs
+++ b/InstagramAutomation.Tests/PasswordServiceTests.cs
@@ -1,0 +1,21 @@
+using InstagramAutomation.Api.Services;
+using Xunit;
+
+public class PasswordServiceTests
+{
+    [Fact]
+    public void HashAndVerifyPassword_Works()
+    {
+        var service = new PasswordService();
+        var hash = service.HashPassword("StrongP@ss1");
+        Assert.True(service.VerifyPassword("StrongP@ss1", hash));
+    }
+
+    [Fact]
+    public void IsPasswordStrong_ValidatesRequirements()
+    {
+        var service = new PasswordService();
+        Assert.True(service.IsPasswordStrong("Abc123!@#"));
+        Assert.False(service.IsPasswordStrong("weak"));
+    }
+}

--- a/InstagramAutomation.sln
+++ b/InstagramAutomation.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstagramAutomation.Api", "InstagramAutomation.Api\InstagramAutomation.Api.csproj", "{4722B39A-9A75-4B34-8804-4053774B2932}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstagramAutomation.Tests", "InstagramAutomation.Tests\InstagramAutomation.Tests.csproj", "{1B4AD838-33CA-4F9D-9B20-4EE893A84E4E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{4722B39A-9A75-4B34-8804-4053774B2932}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4722B39A-9A75-4B34-8804-4053774B2932}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4722B39A-9A75-4B34-8804-4053774B2932}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4722B39A-9A75-4B34-8804-4053774B2932}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {4722B39A-9A75-4B34-8804-4053774B2932}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1B4AD838-33CA-4F9D-9B20-4EE893A84E4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1B4AD838-33CA-4F9D-9B20-4EE893A84E4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1B4AD838-33CA-4F9D-9B20-4EE893A84E4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1B4AD838-33CA-4F9D-9B20-4EE893A84E4E}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Instagram Automation API
+
+This project provides a minimal Web API for managing Instagram accounts and automation rules. It is written in **.NET 8** and uses **SQLite** for storage.
+
+## Requirements
+- .NET 8 SDK
+- SQLite (included by default)
+
+## Configuration
+1. Copy `InstagramAutomation.Api/appsettings.json` to `InstagramAutomation.Api/appsettings.Development.json` and update the following values:
+   - `ConnectionStrings:DefaultConnection` – path to the SQLite database file.
+   - `JwtSettings:SecretKey` – secret key used to sign JWT tokens.
+   - `Instagram` section – credentials from your Meta application (client id, secret and webhook verify token).
+2. Alternatively, these values can be supplied via environment variables.
+
+## Running the API
+```
+dotnet run --project InstagramAutomation.Api/InstagramAutomation.Api.csproj
+```
+The first run will create a SQLite database file. Swagger UI is available at `/swagger` when running in development mode.
+
+## Tests
+```
+dotnet test
+```
+
+## Webhooks
+Configure your Instagram App webhook to the endpoint:
+```
+https://<host>/api/webhook
+```
+The verification token must match `Instagram:WebhookVerifyToken`.


### PR DESCRIPTION
## Summary
- register InstagramApiService in DI
- accept `full_name` JSON but keep C# property `FullName`
- add webhook controller handling comment events
- add unit tests for JWT and password services
- add README with setup instructions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889310c05d0832eb8cbc6146518e612