### PR TITLE
Switch backend to MariaDB

### DIFF
--- a/InstagramAutomation.Api/Data/ApplicationDbContext.cs
+++ b/InstagramAutomation.Api/Data/ApplicationDbContext.cs
@@ -23,8 +23,8 @@ public class ApplicationDbContext : DbContext
         modelBuilder.Entity<User>(entity =>
         {
             entity.HasIndex(e => e.Email).IsUnique();
-            entity.Property(e => e.CreatedAt).HasDefaultValueSql("datetime('now')");
-            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("datetime('now')");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 
         // InstagramAccount configuration
@@ -32,8 +32,8 @@ public class ApplicationDbContext : DbContext
         {
             entity.HasIndex(e => e.InstagramUserId).IsUnique();
             entity.HasIndex(e => e.Username);
-            entity.Property(e => e.CreatedAt).HasDefaultValueSql("datetime('now')");
-            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("datetime('now')");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(d => d.User)
                 .WithMany(p => p.InstagramAccounts)
@@ -45,8 +45,8 @@ public class ApplicationDbContext : DbContext
         modelBuilder.Entity<AutomationRule>(entity =>
         {
             entity.HasIndex(e => new { e.UserId, e.Name });
-            entity.Property(e => e.CreatedAt).HasDefaultValueSql("datetime('now')");
-            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("datetime('now')");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(d => d.User)
                 .WithMany(p => p.AutomationRules)
@@ -65,7 +65,7 @@ public class ApplicationDbContext : DbContext
             entity.HasIndex(e => e.CommentId).IsUnique();
             entity.HasIndex(e => new { e.InstagramAccountId, e.CommentTimestamp });
             entity.HasIndex(e => e.Processed);
-            entity.Property(e => e.CreatedAt).HasDefaultValueSql("datetime('now')");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(d => d.InstagramAccount)
                 .WithMany(p => p.CommentEvents)
@@ -79,7 +79,7 @@ public class ApplicationDbContext : DbContext
             entity.HasIndex(e => new { e.CommentEventId, e.ActionType });
             entity.HasIndex(e => e.Status);
             entity.HasIndex(e => e.NextRetryAt);
-            entity.Property(e => e.CreatedAt).HasDefaultValueSql("datetime('now')");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity.HasOne(d => d.CommentEvent)
                 .WithMany(p => p.ActionExecutions)

--- a/InstagramAutomation.Api/InstagramAutomation.Api.csproj
+++ b/InstagramAutomation.Api/InstagramAutomation.Api.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/InstagramAutomation.Api/Program.cs
+++ b/InstagramAutomation.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using InstagramAutomation.Api.Data;
 using InstagramAutomation.Api.Services;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,8 +14,10 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Database
+var dbConnection = builder.Configuration.GetConnectionString("DefaultConnection")
+                  ?? "Server=localhost;Database=instagram_automation;User=root;Password=pass";
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=instagram_automation.db"));
+    options.UseMySql(dbConnection, ServerVersion.AutoDetect(dbConnection)));
 
 // Services
 builder.Services.AddScoped<IJwtService, JwtService>();

--- a/InstagramAutomation.Api/appsettings.json
+++ b/InstagramAutomation.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=instagram_automation.db"
+    "DefaultConnection": "Server=localhost;Database=instagram_automation;User=root;Password=pass"
   },
   "JwtSettings": {
     "SecretKey": "sua-chave-secreta-super-segura-de-pelo-menos-32-caracteres-aqui",

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Instagram Automation API
 
-This project provides a minimal Web API for managing Instagram accounts and automation rules. It is written in **.NET 8** and uses **SQLite** for storage.
+This project provides a minimal Web API for managing Instagram accounts and automation rules. It is written in **.NET 8** and uses **MariaDB** for storage.
 
 ## Requirements
 - .NET 8 SDK
-- SQLite (included by default)
+- MariaDB server
 
 ## Configuration
 1. Copy `InstagramAutomation.Api/appsettings.json` to `InstagramAutomation.Api/appsettings.Development.json` and update the following values:
-   - `ConnectionStrings:DefaultConnection` – path to the SQLite database file.
+   - `ConnectionStrings:DefaultConnection` – connection string for your MariaDB database.
    - `JwtSettings:SecretKey` – secret key used to sign JWT tokens.
    - `Instagram` section – credentials from your Meta application (client id, secret and webhook verify token).
 2. Alternatively, these values can be supplied via environment variables.
@@ -17,7 +17,7 @@ This project provides a minimal Web API for managing Instagram accounts and auto
 ```
 dotnet run --project InstagramAutomation.Api/InstagramAutomation.Api.csproj
 ```
-The first run will create a SQLite database file. Swagger UI is available at `/swagger` when running in development mode.
+The first run will create the MariaDB schema if it does not already exist. Swagger UI is available at `/swagger` when running in development mode.
 
 ## Tests
 ```


### PR DESCRIPTION
## Summary
- use MariaDB provider instead of SQLite
- update default connection string and README instructions
- change EF default SQL expressions to `CURRENT_TIMESTAMP`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b76f3b530832e8c04e9d0ba0abcc6