### PR TITLE
Add support for business login webhook

### DIFF
--- a/InstagramAutomation.Api/Controllers/WebhookController.cs
+++ b/InstagramAutomation.Api/Controllers/WebhookController.cs
@@ -55,7 +55,17 @@ public class WebhookController : ControllerBase
             if (account == null)
                 continue;
 
-            foreach (var change in entry.Changes)
+            var changes = entry.Changes?.ToList() ?? new List<WebhookChange>();
+            if (!string.IsNullOrEmpty(entry.Field) && entry.Value != null)
+            {
+                changes.Add(new WebhookChange
+                {
+                    Field = entry.Field!,
+                    Value = entry.Value!
+                });
+            }
+
+            foreach (var change in changes)
             {
                 if (change.Field != "comments")
                     continue;

--- a/InstagramAutomation.Api/DTOs/InstagramDTOs.cs
+++ b/InstagramAutomation.Api/DTOs/InstagramDTOs.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace InstagramAutomation.Api.DTOs;
 
@@ -135,7 +136,11 @@ public class WebhookEntry
 {
     public string Id { get; set; } = string.Empty;
     public long Time { get; set; }
-    public List<WebhookChange> Changes { get; set; } = new();
+    public List<WebhookChange>? Changes { get; set; }
+
+    // Business Login payloads can provide field/value directly
+    public string? Field { get; set; }
+    public WebhookValue? Value { get; set; }
 }
 
 public class WebhookChange
@@ -161,6 +166,9 @@ public class WebhookFrom
 public class WebhookMedia
 {
     public string Id { get; set; } = string.Empty;
+
+    // field is named media_product_type in the webhook payload
+    [JsonPropertyName("media_product_type")]
     public string MediaType { get; set; } = string.Empty;
 }
 

--- a/InstagramAutomation.Tests/InstagramAutomation.Tests.csproj
+++ b/InstagramAutomation.Tests/InstagramAutomation.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InstagramAutomation.Api\InstagramAutomation.Api.csproj" />

--- a/InstagramAutomation.Tests/WebhookControllerTests.cs
+++ b/InstagramAutomation.Tests/WebhookControllerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
+using InstagramAutomation.Api.Controllers;
+using InstagramAutomation.Api.Data;
+using InstagramAutomation.Api.DTOs;
+using InstagramAutomation.Api.Models;
+using InstagramAutomation.Api.Services;
+using Xunit;
+
+public class WebhookControllerTests
+{
+    [Fact]
+    public async Task Receive_WithBusinessLoginPayload_StoresCommentEvent()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "webhook_db")
+            .Options;
+        using var context = new ApplicationDbContext(options);
+
+        context.InstagramAccounts.Add(new InstagramAccount
+        {
+            Id = 1,
+            InstagramUserId = "123",
+            Username = "testuser"
+        });
+        context.SaveChanges();
+
+        var config = new ConfigurationBuilder().Build();
+        var controller = new WebhookController(config, context, new StubInstagramApiService(), NullLogger<WebhookController>.Instance);
+
+        var request = new WebhookRequest
+        {
+            Object = "instagram",
+            Entry = new List<WebhookEntry>
+            {
+                new WebhookEntry
+                {
+                    Id = "123",
+                    Time = 1710687834,
+                    Field = "comments",
+                    Value = new WebhookValue
+                    {
+                        Id = "c1",
+                        Text = "Nice post",
+                        From = new WebhookFrom{ Id = "u1", Username = "john" },
+                        Media = new WebhookMedia{ Id = "m1", MediaType = "FEED" }
+                    }
+                }
+            }
+        };
+
+        var result = await controller.Receive(request);
+        Assert.IsType<OkResult>(result);
+        var ev = context.CommentEvents.Single();
+        Assert.Equal("c1", ev.CommentId);
+        Assert.Equal("john", ev.CommenterUsername);
+        Assert.Equal("Nice post", ev.CommentText);
+        Assert.Equal("FEED", ev.MediaType);
+    }
+
+    private class StubInstagramApiService : IInstagramApiService
+    {
+        public Task<InstagramUserInfo?> GetUserInfoAsync(string accessToken) => Task.FromResult<InstagramUserInfo?>(null);
+        public Task<bool> ValidateAccessTokenAsync(string accessToken) => Task.FromResult(true);
+        public Task<bool> PostCommentReplyAsync(string accessToken, string commentId, string message) => Task.FromResult(true);
+        public Task<bool> SendPrivateMessageAsync(string accessToken, string userId, string message) => Task.FromResult(true);
+        public Task<List<InstagramMedia>> GetUserMediaAsync(string accessToken, int limit = 10) => Task.FromResult(new List<InstagramMedia>());
+    }
+}


### PR DESCRIPTION
## Summary
- handle Business Login style webhook payloads
- map `media_product_type` to `WebhookMedia.MediaType`
- extend webhook deserialization to accept `field`/`value`
- test webhook controller with sample payload

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ccd10e28c832e86dcf041e1d69fc8